### PR TITLE
Add configurable scoring calibration tooling

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from cachetools import TTLCache
@@ -28,79 +28,149 @@ DS_NEW_CACHE: TTLCache = TTLCache(maxsize=200, ttl=180)
 
 def _compute_sss(i: Dict[str, Any]) -> int:
     """Calculates a score based on immediate, on-chain rugpull risks."""
-    score = 80  # start lower so early coins don't auto-moon
+    cfg = CONFIG.get("SSS_SCORING", {})
+    score = float(cfg.get("base_score", 80))
+
     # Strong penalty for active authorities (but not hard zero)
-    if i.get('mint_authority') or i.get('freeze_authority'):
-        score -= 60
+    if i.get("mint_authority") or i.get("freeze_authority"):
+        score -= float(cfg.get("authority_penalty", 60))
 
-    if (pct := i.get("top10_holder_percentage")):
-        if pct >= 80: score -= 40
-        elif pct >= 60: score -= 25
-        elif pct >= 40: score -= 10
+    pct = i.get("top10_holder_percentage")
+    if pct is not None:
+        try:
+            pct_val = float(pct)
+        except (TypeError, ValueError):
+            pct_val = None
+        if pct_val is not None:
+            thresholds = cfg.get("top_holder_thresholds", [80, 60, 40])
+            penalties = cfg.get("top_holder_penalties", [40, 25, 10])
+            bucketed: List[tuple[float, float]] = []
+            for threshold, penalty in zip(thresholds, penalties):
+                try:
+                    bucketed.append((float(threshold), float(penalty)))
+                except (TypeError, ValueError):
+                    continue
+            for threshold, penalty in sorted(bucketed, key=lambda x: x[0], reverse=True):
+                if pct_val >= threshold:
+                    score -= penalty
+                    break
 
-    if (rug_score := i.get("rugcheck_score", "")):
-        if "High Risk" in rug_score: score -= 30
-    
-    if (count := i.get("creator_token_count", 0)) > 5:
-        score -= min((count * 3), 25)
+    rug_score = i.get("rugcheck_score", "")
+    if isinstance(rug_score, str) and "high risk" in rug_score.lower():
+        score -= float(cfg.get("rug_high_risk_penalty", 30))
+
+    count = i.get("creator_token_count", 0)
+    try:
+        count_val = int(count)
+    except (TypeError, ValueError):
+        count_val = 0
+    start = int(cfg.get("creator_penalty_start", 5))
+    if count_val > start:
+        per_token = float(cfg.get("creator_penalty_per_token", 3))
+        cap = float(cfg.get("creator_penalty_cap", 25))
+        penalty = min((count_val - start) * per_token, cap)
+        score -= penalty
 
     return max(0, int(score))
 
 def _compute_mms(i: Dict[str, Any]) -> int:
     """Market health with age-aware expectations."""
+    cfg = CONFIG.get("MMS_SCORING", {})
     liq = float(i.get("liquidity_usd") or 0)
     vol = float(i.get("volume_24h_usd") or 0)
     mc = float(i.get("market_cap_usd") or 0)
     age_m = float(i.get("age_minutes") or 0)
 
-    if age_m < 360:
-        liq_weight, vol_weight, mc_weight = 0.3, 0.3, 0.2
-        liq_norm, vol_norm, mc_norm = 5_000, 25_000, 50_000
-        cap = 60
-    elif age_m < 1440:
-        liq_weight, vol_weight, mc_weight = 0.35, 0.35, 0.2
-        liq_norm, vol_norm, mc_norm = 15_000, 75_000, 150_000
-        cap = 70
-    elif age_m < 10080:
-        liq_weight, vol_weight, mc_weight = 0.35, 0.35, 0.2
-        liq_norm, vol_norm, mc_norm = 50000, 200000, 500000
-        cap = 85
-    else:
-        liq_weight, vol_weight, mc_weight = 0.35, 0.35, 0.2
-        liq_norm, vol_norm, mc_norm = 150000, 400000, 1000000
-        cap = 90
+    brackets = cfg.get("age_brackets") or []
+    bracket: Dict[str, Any] = {}
+    for candidate in brackets:
+        max_age = candidate.get("max_age_minutes")
+        try:
+            max_age_val = float(max_age) if max_age is not None else None
+        except (TypeError, ValueError):
+            max_age_val = None
+        if max_age_val is None or age_m < max_age_val:
+            bracket = candidate
+            break
+    if not bracket and brackets:
+        bracket = brackets[-1]
 
-    def norm(x, k):
-        return x / (x + k) if x >= 0 else 0
+    weights = bracket.get("weights", {})
+    norms = bracket.get("norms", {})
+    liq_weight = float(weights.get("liquidity", 0.35))
+    vol_weight = float(weights.get("volume", 0.35))
+    mc_weight = float(weights.get("market_cap", 0.2))
+    liq_norm = float(norms.get("liquidity", 5_000))
+    vol_norm = float(norms.get("volume", 25_000))
+    mc_norm = float(norms.get("market_cap", 50_000))
+    cap = int(bracket.get("cap", 90))
+
+    def norm(x: float, k: float) -> float:
+        try:
+            k_val = float(k)
+        except (TypeError, ValueError):
+            k_val = 0.0
+        if x < 0:
+            return 0.0
+        if k_val <= 0:
+            return 1.0 if x > 0 else 0.0
+        return x / (x + k_val)
 
     score = 0.0
     score += liq_weight * 100 * norm(liq, liq_norm)
     score += vol_weight * 100 * norm(vol, vol_norm)
     score += mc_weight * 100 * norm(mc, mc_norm)
 
+    follower_cfg = cfg.get("twitter_followers", {})
     if (stats := i.get("twitter_stats")):
         followers = int(stats.get("followers", 0) or 0)
-        score += 10 * norm(followers, 10000)
+        weight = float(follower_cfg.get("weight", 10.0))
+        follower_norm = float(follower_cfg.get("norm", 10_000))
+        score += weight * norm(followers, follower_norm)
 
-    # Dead-market clamps: extremely low volume relative to age caps MMS regardless of MC/Liq
-    if age_m >= 1440 and vol < 1000:
-        score = min(score, 20)
-    elif age_m >= 360 and vol < 500:
-        score = min(score, 25)
-    elif vol < 100:
-        score = min(score, 15)
+    volume_clamps = cfg.get("volume_clamp_rules") or [
+        {"min_age_minutes": 1440, "max_volume": 1_000, "cap": 20},
+        {"min_age_minutes": 360, "max_volume": 500, "cap": 25},
+        {"min_age_minutes": 0, "max_volume": 100, "cap": 15},
+    ]
+    for clamp in volume_clamps:
+        try:
+            min_age = float(clamp.get("min_age_minutes", 0) or 0)
+            max_volume = float(clamp.get("max_volume", 0) or 0)
+            clamp_cap = float(clamp.get("cap", cap))
+        except (TypeError, ValueError):
+            continue
+        if age_m >= min_age and vol < max_volume:
+            score = min(score, clamp_cap)
+            break
 
-    # If price hasn't moved and volume is tiny, cap even harder (likely dead/rugged)
     try:
         pchg = abs(float(i.get("price_change_24h") or 0.0))
     except Exception:
         pchg = 0.0
-    if vol < 100 and pchg < 0.1:
-        score = min(score, 10)
+    price_cap_cfg = cfg.get("price_change_cap") or {"max_volume": 100, "max_price_change": 0.1, "cap": 10}
+    try:
+        price_cap_volume = float(price_cap_cfg.get("max_volume", 100) or 0)
+        price_cap_delta = float(price_cap_cfg.get("max_price_change", 0.1) or 0)
+        price_cap_value = float(price_cap_cfg.get("cap", 10))
+    except (TypeError, ValueError):
+        price_cap_volume = 100.0
+        price_cap_delta = 0.1
+        price_cap_value = 10.0
+    if vol < price_cap_volume and pchg < price_cap_delta:
+        score = min(score, price_cap_value)
 
-    # Liquidity-volume mismatch: large liq but near-zero volume indicates dead pool
-    if liq > 100_000 and vol < 1_000:
-        score = min(score, 20)
+    lv_cfg = cfg.get("liquidity_volume_cap") or {"min_liquidity": 100_000, "max_volume": 1_000, "cap": 20}
+    try:
+        min_liq = float(lv_cfg.get("min_liquidity", 100_000) or 0)
+        lv_max_vol = float(lv_cfg.get("max_volume", 1_000) or 0)
+        lv_cap = float(lv_cfg.get("cap", 20))
+    except (TypeError, ValueError):
+        min_liq = 100_000.0
+        lv_max_vol = 1_000.0
+        lv_cap = 20.0
+    if liq > min_liq and vol < lv_max_vol:
+        score = min(score, lv_cap)
 
     return max(0, min(int(score), cap))
 

--- a/calibrate_scoring.py
+++ b/calibrate_scoring.py
@@ -1,0 +1,410 @@
+"""Calibration utilities for MMS/SSS scoring parameters.
+
+This script ingests historical token data and recommends new configuration
+values for the MMS (market health) and SSS (safety) scoring systems.  The
+output can be written to stdout or to a file and consumed via the environment
+variables ``MMS_SCORING`` and ``SSS_SCORING`` (JSON encoded) before starting
+Token Tony.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from config import CONFIG
+
+
+def _mean(values: Sequence[float]) -> Optional[float]:
+    filtered = [v for v in values if v is not None]
+    if not filtered:
+        return None
+    return sum(filtered) / len(filtered)
+
+
+def _percentile(values: Sequence[float], q: float) -> Optional[float]:
+    if not values:
+        return None
+    if q <= 0:
+        return min(values)
+    if q >= 1:
+        return max(values)
+    data = sorted(values)
+    pos = (len(data) - 1) * q
+    floor = math.floor(pos)
+    ceil = math.ceil(pos)
+    if floor == ceil:
+        return data[int(pos)]
+    lower = data[floor]
+    upper = data[ceil]
+    return lower + (upper - lower) * (pos - floor)
+
+
+def _safe_float(value: Any, default: Optional[float] = 0.0) -> Optional[float]:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: Optional[int] = 0) -> Optional[int]:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _deepcopy(data: Any) -> Any:
+    return json.loads(json.dumps(data))
+
+
+def _load_records(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"No historical data found at {path}")
+    if path.suffix.lower() == ".csv":
+        with path.open("r", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            return [dict(row) for row in reader]
+    if path.suffix.lower() in {".json", ".jsonl"}:
+        text = path.read_text(encoding="utf-8")
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, list):
+            return [dict(x) for x in payload if isinstance(x, dict)]
+        # Assume JSONL fallback
+        records: List[Dict[str, Any]] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                records.append(obj)
+        return records
+    raise ValueError(f"Unsupported historical data format: {path.suffix}")
+
+
+def _calibrate_sss(records: Iterable[Dict[str, Any]], target_field: str) -> Dict[str, Any]:
+    defaults = _deepcopy(CONFIG.get("SSS_SCORING", {})) or {}
+    if not defaults:
+        return defaults
+
+    thresholds_raw = list(zip(
+        defaults.get("top_holder_thresholds", [80, 60, 40]),
+        defaults.get("top_holder_penalties", [40, 25, 10]),
+    ))
+    try:
+        threshold_pairs: List[Tuple[float, float]] = [
+            (float(thr), float(pen)) for thr, pen in thresholds_raw
+        ]
+    except (TypeError, ValueError):
+        threshold_pairs = [(80.0, 40.0), (60.0, 25.0), (40.0, 10.0)]
+    threshold_pairs.sort(key=lambda x: x[0], reverse=True)
+
+    holder_samples: Dict[float, List[float]] = {thr: [] for thr, _ in threshold_pairs}
+    baseline_scores: List[float] = []
+    authority_scores: List[float] = []
+    rug_scores: List[float] = []
+    creator_samples: List[Tuple[int, float]] = []
+
+    baseline_threshold = min([pair[0] for pair in threshold_pairs], default=40.0)
+    creator_start = int(defaults.get("creator_penalty_start", 5))
+
+    for record in records:
+        raw_target = record.get(target_field)
+        target = _safe_float(raw_target, None)
+        if target is None:
+            continue
+
+        authority = bool(record.get("mint_authority")) or bool(record.get("freeze_authority"))
+        pct_val = _safe_float(record.get("top10_holder_percentage"), None)
+        rug_score = str(record.get("rugcheck_score", "") or "")
+        creator_count = _safe_int(record.get("creator_token_count"), None) or 0
+
+        is_baseline = (
+            not authority
+            and (pct_val is None or pct_val < baseline_threshold)
+            and "high risk" not in rug_score.lower()
+            and creator_count <= creator_start
+        )
+        if is_baseline:
+            baseline_scores.append(target)
+
+        if authority:
+            authority_scores.append(target)
+
+        if pct_val is not None:
+            for thr, _ in threshold_pairs:
+                if pct_val >= thr:
+                    holder_samples.setdefault(thr, []).append(target)
+                    break
+
+        if "high risk" in rug_score.lower():
+            rug_scores.append(target)
+
+        if creator_count > creator_start:
+            creator_samples.append((creator_count, target))
+
+    baseline_mean = _mean(baseline_scores)
+    if baseline_mean is None:
+        baseline_mean = float(defaults.get("base_score", 80))
+    base_score = max(0.0, min(100.0, baseline_mean))
+
+    authority_mean = _mean(authority_scores)
+    if authority_mean is not None:
+        authority_penalty = max(0.0, base_score - authority_mean)
+    else:
+        authority_penalty = float(defaults.get("authority_penalty", 60))
+
+    updated_penalties: List[float] = []
+    for thr, default_penalty in threshold_pairs:
+        samples = holder_samples.get(thr) or []
+        sample_mean = _mean(samples)
+        if sample_mean is not None:
+            updated_penalties.append(max(0.0, base_score - sample_mean))
+        else:
+            updated_penalties.append(float(default_penalty))
+
+    rug_mean = _mean(rug_scores)
+    if rug_mean is not None:
+        rug_penalty = max(0.0, base_score - rug_mean)
+    else:
+        rug_penalty = float(defaults.get("rug_high_risk_penalty", 30))
+
+    creator_penalty = float(defaults.get("creator_penalty_per_token", 3))
+    if creator_samples:
+        per_token_deltas: List[float] = []
+        for count, sample_score in creator_samples:
+            extra = max(1, count - creator_start)
+            drop = base_score - sample_score
+            if drop > 0:
+                per_token_deltas.append(drop / extra)
+        delta_mean = _mean(per_token_deltas)
+        if delta_mean is not None:
+            creator_cap = float(defaults.get("creator_penalty_cap", 25))
+            creator_penalty = min(creator_cap, max(0.0, delta_mean))
+
+    # Compose the final structure preserving order from defaults
+    thresholds_sorted = [int(round(thr)) for thr, _ in threshold_pairs]
+    penalties_sorted = [round(pen, 2) for pen in updated_penalties]
+
+    updated = _deepcopy(defaults)
+    updated["base_score"] = int(round(base_score))
+    updated["authority_penalty"] = int(round(authority_penalty))
+    updated["top_holder_thresholds"] = thresholds_sorted
+    updated["top_holder_penalties"] = [int(round(p)) for p in penalties_sorted]
+    updated["rug_high_risk_penalty"] = int(round(rug_penalty))
+    updated["creator_penalty_per_token"] = round(creator_penalty, 2)
+
+    return updated
+
+
+def _assign_bracket(age: float, brackets: Sequence[Dict[str, Any]]) -> int:
+    for idx, bracket in enumerate(brackets):
+        max_age = bracket.get("max_age_minutes")
+        try:
+            limit = float(max_age) if max_age is not None else None
+        except (TypeError, ValueError):
+            limit = None
+        if limit is None or age < limit:
+            return idx
+    return len(brackets) - 1 if brackets else -1
+
+
+def _correlation(xs: Sequence[float], ys: Sequence[float]) -> float:
+    if len(xs) != len(ys) or len(xs) < 2:
+        return 0.0
+    mean_x = _mean(xs)
+    mean_y = _mean(ys)
+    if mean_x is None or mean_y is None:
+        return 0.0
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den_x = math.sqrt(sum((x - mean_x) ** 2 for x in xs))
+    den_y = math.sqrt(sum((y - mean_y) ** 2 for y in ys))
+    if den_x == 0 or den_y == 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
+def _calibrate_mms(
+    records: Iterable[Dict[str, Any]],
+    target_field: str,
+    performance_threshold: float,
+    quantile: float,
+) -> Dict[str, Any]:
+    defaults = _deepcopy(CONFIG.get("MMS_SCORING", {})) or {}
+    brackets = defaults.get("age_brackets")
+    if not defaults or not brackets:
+        return defaults
+
+    bucketed: Dict[int, List[Dict[str, Any]]] = {idx: [] for idx in range(len(brackets))}
+    for record in records:
+        age_val = _safe_float(record.get("age_minutes"), None)
+        if age_val is None:
+            continue
+        idx = _assign_bracket(age_val, brackets)
+        if idx >= 0:
+            bucketed.setdefault(idx, []).append(record)
+
+    updated_brackets: List[Dict[str, Any]] = []
+    for idx, bracket in enumerate(brackets):
+        bucket = bucketed.get(idx, [])
+        if not bucket:
+            updated_brackets.append(_deepcopy(bracket))
+            continue
+
+        # Separate performance bands
+        perf_candidates = []
+        high_perf = []
+        for record in bucket:
+            target = _safe_float(record.get(target_field), None)
+            if target is None:
+                continue
+            perf_candidates.append((record, target))
+            if target >= performance_threshold:
+                high_perf.append((record, target))
+        if len(high_perf) < 3:
+            high_perf = perf_candidates
+        if not perf_candidates:
+            updated_brackets.append(_deepcopy(bracket))
+            continue
+
+        def _collect(series: List[Tuple[Dict[str, Any], float]], key: str) -> List[float]:
+            out: List[float] = []
+            for rec, _ in series:
+                val = _safe_float(rec.get(key), None)
+                if val is not None and val >= 0:
+                    out.append(val)
+            return out
+
+        liq_values = _collect(high_perf, "liquidity_usd")
+        vol_values = _collect(high_perf, "volume_24h_usd")
+        mc_values = _collect(high_perf, "market_cap_usd")
+
+        updated_norms = {
+            "liquidity": _percentile(liq_values, quantile)
+            or bracket.get("norms", {}).get("liquidity", 5_000),
+            "volume": _percentile(vol_values, quantile)
+            or bracket.get("norms", {}).get("volume", 25_000),
+            "market_cap": _percentile(mc_values, quantile)
+            or bracket.get("norms", {}).get("market_cap", 50_000),
+        }
+
+        # Correlation-driven weights
+        liq_series = []
+        vol_series = []
+        mc_series = []
+        target_series = []
+        for rec, target in perf_candidates:
+            liq_val = _safe_float(rec.get("liquidity_usd"), None)
+            vol_val = _safe_float(rec.get("volume_24h_usd"), None)
+            mc_val = _safe_float(rec.get("market_cap_usd"), None)
+            if None in (liq_val, vol_val, mc_val):
+                continue
+            liq_series.append(max(0.0, liq_val))
+            vol_series.append(max(0.0, vol_val))
+            mc_series.append(max(0.0, mc_val))
+            target_series.append(max(0.0, target))
+
+        default_weights = bracket.get("weights", {})
+        total_default_weight = sum(
+            float(default_weights.get(key, 0)) for key in ("liquidity", "volume", "market_cap")
+        )
+        if total_default_weight <= 0:
+            total_default_weight = 1.0
+
+        corrs = [
+            abs(_correlation(series, target_series))
+            for series in (liq_series, vol_series, mc_series)
+        ]
+        if sum(corrs) > 0:
+            scale = total_default_weight / sum(corrs)
+            new_weights = [c * scale for c in corrs]
+        else:
+            new_weights = [float(default_weights.get(key, 0)) for key in ("liquidity", "volume", "market_cap")]
+
+        updated_bracket = _deepcopy(bracket)
+        updated_bracket.setdefault("weights", {})
+        updated_bracket.setdefault("norms", {})
+        for metric, value in updated_norms.items():
+            if value is None or value <= 0:
+                continue
+            updated_bracket["norms"][metric] = round(float(value), 2)
+        for metric, weight in zip(("liquidity", "volume", "market_cap"), new_weights):
+            updated_bracket["weights"][metric] = round(float(weight), 4)
+
+        updated_brackets.append(updated_bracket)
+
+    updated = _deepcopy(defaults)
+    updated["age_brackets"] = updated_brackets
+    return updated
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Calibrate MMS/SSS scoring parameters")
+    parser.add_argument("input", help="Historical dataset (CSV, JSON or JSONL)")
+    parser.add_argument("--output", help="Optional path to write the recommended configuration JSON")
+    parser.add_argument(
+        "--sss-target-field",
+        default="observed_sss",
+        help="Field containing the realised SSS score (default: observed_sss)",
+    )
+    parser.add_argument(
+        "--mms-target-field",
+        default="observed_mms",
+        help="Field containing the realised MMS score (default: observed_mms)",
+    )
+    parser.add_argument(
+        "--performance-threshold",
+        type=float,
+        default=70.0,
+        help="Minimum realised MMS score treated as high performing",
+    )
+    parser.add_argument(
+        "--quantile",
+        type=float,
+        default=0.75,
+        help="Quantile used for normalisation constants (default: 0.75)",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    dataset_path = Path(args.input)
+    records = _load_records(dataset_path)
+    if not records:
+        raise SystemExit("No usable historical records found for calibration")
+
+    sss_config = _calibrate_sss(records, args.sss_target_field)
+    mms_config = _calibrate_mms(records, args.mms_target_field, args.performance_threshold, args.quantile)
+
+    output = {"SSS_SCORING": sss_config, "MMS_SCORING": mms_config}
+    payload = json.dumps(output, indent=2, sort_keys=True)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+        print(f"Wrote calibrated configuration to {output_path}")
+    else:
+        print(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,88 @@
+import copy
+import sys
+import types
+
+import pytest
+
+# Provide lightweight stubs so `analysis` can import optional helpers during tests.
+_helpers_pkg = types.ModuleType("tony_helpers")
+_helpers_api = types.ModuleType("tony_helpers.api")
+_helpers_db = types.ModuleType("tony_helpers.db")
+
+for name in (
+    "_is_ipfs_uri",
+    "fetch_birdeye",
+    "fetch_creator_dossier_bitquery",
+    "fetch_dexscreener_by_mint",
+    "fetch_gecko_market_data",
+    "fetch_helius_asset",
+    "fetch_holders_count_via_rpc",
+    "fetch_ipfs_json",
+    "fetch_jupiter_has_route",
+    "fetch_rugcheck_score",
+    "fetch_top10_via_rpc",
+    "fetch_twitter_stats",
+):
+    setattr(_helpers_api, name, lambda *args, **kwargs: None)
+
+setattr(_helpers_db, "_execute_db", lambda *args, **kwargs: None)
+
+_helpers_pkg.api = _helpers_api
+_helpers_pkg.db = _helpers_db
+
+sys.modules.setdefault("tony_helpers", _helpers_pkg)
+sys.modules.setdefault("tony_helpers.api", _helpers_api)
+sys.modules.setdefault("tony_helpers.db", _helpers_db)
+
+from analysis import _compute_mms, _compute_sss
+from config import CONFIG
+
+
+@pytest.fixture(autouse=True)
+def restore_scoring_config():
+    original_sss = copy.deepcopy(CONFIG.get("SSS_SCORING", {}))
+    original_mms = copy.deepcopy(CONFIG.get("MMS_SCORING", {}))
+    yield
+    CONFIG["SSS_SCORING"] = original_sss
+    CONFIG["MMS_SCORING"] = original_mms
+
+
+def test_sss_score_reflects_authority_penalty():
+    sample = {
+        "mint_authority": "SomeAuthority",
+        "freeze_authority": None,
+        "top10_holder_percentage": 10,
+        "rugcheck_score": "Low",
+        "creator_token_count": 1,
+    }
+
+    baseline = _compute_sss(sample)
+
+    updated = copy.deepcopy(CONFIG["SSS_SCORING"])
+    updated["authority_penalty"] = updated.get("authority_penalty", 60) + 10
+    CONFIG["SSS_SCORING"] = updated
+
+    adjusted = _compute_sss(sample)
+    assert adjusted == max(0, baseline - 10)
+
+
+def test_mms_score_changes_with_norm_adjustment():
+    sample = {
+        "liquidity_usd": 25_000,
+        "volume_24h_usd": 15_000,
+        "market_cap_usd": 75_000,
+        "age_minutes": 120,
+        "twitter_stats": {"followers": 5000},
+        "price_change_24h": 5.0,
+    }
+
+    baseline = _compute_mms(sample)
+
+    updated = copy.deepcopy(CONFIG["MMS_SCORING"])
+    first_bracket = updated["age_brackets"][0]
+    for metric in ("liquidity", "volume", "market_cap"):
+        first_bracket["norms"][metric] = 1_000_000
+    CONFIG["MMS_SCORING"] = updated
+
+    adjusted = _compute_mms(sample)
+    assert adjusted < baseline


### PR DESCRIPTION
## Summary
- move the MMS and SSS weighting/normalisation knobs into `config.py` with JSON-friendly overrides
- update the scoring helpers to respect the new configuration structures
- introduce a calibration utility that recommends new MMS/SSS settings from historical performance
- add regression tests that confirm scoring output shifts when the configuration changes

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8da19d3ac8324a81a35a20346c258