### PR TITLE
Add RPC failover helper and use it for firehose lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ See `mission.md` for the full Mission & Operating Guide.
     # OWNER_ID=000000000              # Your Telegram user ID for admin commands
     # PUBLIC_CHAT_ID=-100123456789    # Channel/chat ID for public auto-pushes
     # VIP_CHAT_ID=-100987654321       # Channel/chat ID for VIP auto-pushes
-    # HELIUS_API_KEY=...              # Improves discovery & analysis
+    # HELIUS_API_KEY=...              # Primary Solana RPC (HTTP+WS via Helius)
     # BIRDEYE_API_KEY=...             # Improves pricing/market data
     # RUGCHECK_JWT=...                # Optional for RugCheck API
+    # ALCHEMY_RPC_URL=...             # Optional HTTP RPC failover for transaction lookups
+    # SYNDICA_RPC_URL=...             # Optional HTTP RPC failover for transaction lookups
     # ALCHEMY_WS_URL=...              # Optional WS alternative for logs firehose
-    # ALCHEMY_RPC_URL=...
-    # SYNDICA_WS_URL=...
-    # SYNDICA_RPC_URL=...
+    # SYNDICA_WS_URL=...              # Optional WS alternative for logs firehose
     # LOG_KEEP_COUNT=7                # How many rotated logs to keep
     # TONY_LOG_FILE=data/tony_log.log # Where logs are written
     # DB_FILE=data/tony_memory.db     # SQLite DB location
@@ -71,9 +71,13 @@ See `mission.md` for the full Mission & Operating Guide.
     python Token_TonyV10.py
     ```
 
-The bot should now be running. Use `/start` in a DM or configure channel permissions and `/setpublic`/`/setvip` (owner only) to enable auto-pushes.
+  The bot should now be running. Use `/start` in a DM or configure channel permissions and `/setpublic`/`/setvip` (owner only) to enable auto-pushes.
 
-### Maintenance and Cleanup
+  ### RPC failover
+
+  Token Tony automatically cycles through the configured HTTP RPC endpoints when performing JSON-RPC calls (e.g., log firehose transaction lookups). Provide any combination of `HELIUS_RPC_URL` (derived from `HELIUS_API_KEY`), `SYNDICA_RPC_URL`, and `ALCHEMY_RPC_URL`; the bot will try each provider in sequence until one succeeds.
+
+  ### Maintenance and Cleanup
 - The bot runs a background maintenance worker that:
   - Prunes old snapshots/rejected rows per retention settings
   - Drops stale discovered rows to avoid backlog bloat

--- a/rpc_providers.py
+++ b/rpc_providers.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Shared Solana RPC provider helpers.
+
+This module centralizes the list of HTTP RPC endpoints that Token Tony can
+use and exposes a helper for sending JSON-RPC POST requests with automatic
+failover between the configured providers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import httpx
+
+from api import _fetch
+from config import (
+    ALCHEMY_RPC_URL,
+    CONFIG,
+    HELIUS_RPC_URL,
+    SYNDICA_RPC_URL,
+)
+
+log = logging.getLogger("token_tony.rpc")
+
+
+def _build_providers() -> List[Tuple[str, str]]:
+    providers: List[Tuple[str, str]] = []
+    for name, url in (
+        ("Helius", (HELIUS_RPC_URL or "").strip()),
+        ("Syndica", (SYNDICA_RPC_URL or "").strip()),
+        ("Alchemy", (ALCHEMY_RPC_URL or "").strip()),
+    ):
+        if url:
+            providers.append((name, url))
+    return providers
+
+
+RPC_PROVIDERS: List[Tuple[str, str]] = _build_providers()
+
+_RPC_CLIENT: Optional[httpx.AsyncClient] = None
+
+
+async def _get_rpc_client() -> httpx.AsyncClient:
+    global _RPC_CLIENT
+    if _RPC_CLIENT is None:
+        timeout = float(CONFIG.get("HTTP_TIMEOUT", 10.0) or 10.0)
+        _RPC_CLIENT = httpx.AsyncClient(timeout=httpx.Timeout(timeout))
+    return _RPC_CLIENT
+
+
+async def rpc_post(payload: Dict) -> Dict:
+    """Send a JSON-RPC POST request with provider failover."""
+    if not RPC_PROVIDERS:
+        raise RuntimeError("No RPC providers configured.")
+
+    client = await _get_rpc_client()
+    errors: List[str] = []
+
+    for name, url in RPC_PROVIDERS:
+        try:
+            res = await _fetch(client, url, method="POST", json=payload, timeout=10.0)
+        except Exception as exc:  # noqa: BLE001
+            msg = f"RPC provider {name} failed: {exc}"
+            log.warning(msg)
+            errors.append(msg)
+            continue
+
+        if res:
+            if errors:
+                log.info("RPC provider %s succeeded after %d fallback(s).", name, len(errors))
+            return res
+
+        errors.append(f"RPC provider {name} returned no data.")
+
+    raise RuntimeError("; ".join(errors) if errors else "All RPC providers failed.")


### PR DESCRIPTION
## Summary
- add an `rpc_providers` helper that centralizes configured Solana RPC endpoints and performs failover-aware JSON-RPC POSTs
- switch the logs firehose to use `rpc_post` for transaction lookups and ensure at least one HTTP provider is configured before starting
- document the RPC environment variables and new failover behavior in the README

## Testing
- python -m compileall Token_TonyV10.py rpc_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68c8db40afcc8324a2fe7d73ff0d2140